### PR TITLE
Fix deprecation warning for SUIDManager.

### DIFF
--- a/lib/puppet/provider/cs_location/crm.rb
+++ b/lib/puppet/provider/cs_location/crm.rb
@@ -18,7 +18,12 @@ Puppet::Type.type(:cs_location).provide(:crm, :parent => Puppet::Provider::Crmsh
     instances = []
 
     cmd = [ command(:crm), 'configure', 'show', 'xml' ]
-    raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
+    if Puppet::PUPPETVERSION.to_f < 3.4
+       raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
+    else
+       raw = Puppet::Util::Execution.execute(cmd)
+       status = raw.exitstatus
+    end
     doc = REXML::Document.new(raw)
 
     doc.root.elements['configuration'].elements['constraints'].each_element('rsc_location') do |e|


### PR DESCRIPTION
```
Warning: Puppet::Util::SUIDManager.run_and_capture is deprecated; please use Puppet::Util::Execution.execute instead.
   (at /var/lib/puppet/lib/puppet/provider/cs_location/crm.rb:21:in `instances')
```

This is already fixed in all other invocations in the module.