### PR TITLE
Update URLs to refer to new module location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Puppet Labs module for Corosync
 ============================
 
-[![Build Status](https://travis-ci.org/puppetlabs/puppetlabs-corosync.png?branch=master)](https://travis-ci.org/puppetlabs/puppetlabs-corosync)
+[![Build Status](https://travis-ci.org/puppet-community/puppet-corosync.png?branch=master)](https://travis-ci.org/puppet-community/puppet-corosync)
 
 Corosync is a cluster stack written as a reimplementation of all the core
 functionalities required by openais.  Meant to provide 100% correct operation
@@ -208,7 +208,7 @@ there are more incomplete examples spread across the [Puppet Labs Github](https:
 Contributors
 ------------
 
-  * [See Puppet Labs Github](https://github.com/puppetlabs/puppetlabs-corosync/graphs/contributors)
+  * [See Puppet Labs Github](https://github.com/puppet-community/puppet-corosync/graphs/contributors)
 
 Copyright and License
 ---------------------

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
-  "name": "puppetlabs-corosync",
+  "name": "puppet-corosync",
   "version": "0.7.0",
   "author": "Puppet Labs",
   "summary": "This module is a set of manifests and types/providers for quickly setting up highly available clusters using Corosync",
   "license": "Apache License, Version 2.0",
-  "source": "https://github.com/puppetlabs/puppetlabs-corosync",
-  "project_page": "https://github.com/puppetlabs/puppetlabs-corosync",
-  "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
+  "source": "https://github.com/puppet-community/puppet-corosync",
+  "project_page": "https://github.com/puppet-community/puppet-corosync",
+  "issues_url": "https://github.com/puppet-community/puppet-corosync/issues",
   "types": [
   
   ],


### PR DESCRIPTION
I have assumed issues will be logged here rather than in the PuppetLabs tracker now.