### PR TITLE
Implement ensure => $version for pacemaker and corosync package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,6 @@ class corosync::params {
   $debug                               = false
   $rrp_mode                            = 'none'
   $ttl                                 = false
-  $packages                            = ['corosync', 'pacemaker']
   $token                               = 3000
   $token_retransmits_before_lost_const = 10
 


### PR DESCRIPTION
Instead of just installing the corosync and pacemaker version in the present version, sometimes you need to install a specific version and/or not install by it puppet at all.