### PR TITLE
Stop ignoring order of primitives in colocation constraints

### DIFF
--- a/lib/puppet/provider/cs_colocation/pcs.rb
+++ b/lib/puppet/provider/cs_colocation/pcs.rb
@@ -36,12 +36,10 @@ Puppet::Type.type(:cs_colocation).provide(:pcs, :parent => Puppet::Provider::Pac
         with_rsc = items['with-rsc']
       end
 
-      # Sorting the array of primitives because order doesn't matter so someone
-      # switching the order around shouldn't generate an event.
       colocation_instance = {
         :name       => items['id'],
         :ensure     => :present,
-        :primitives => [rsc, with_rsc].sort,
+        :primitives => [rsc, with_rsc],
         :score      => items['score'],
         :provider   => self.name,
         :new        => false
@@ -89,7 +87,7 @@ Puppet::Type.type(:cs_colocation).provide(:pcs, :parent => Puppet::Provider::Pac
   # resource already exists so we just update the current value in the property
   # hash and doing this marks it to be flushed.
   def primitives=(should)
-    @property_hash[:primitives] = should.sort
+    @property_hash[:primitives]
   end
 
   def score=(should)

--- a/lib/puppet/type/cs_group.rb
+++ b/lib/puppet/type/cs_group.rb
@@ -21,13 +21,21 @@ module Puppet
       desc "An array of primitives to have in this group.  Must be listed in the
           order that you wish them to start."
 
+      # We want this to be an array, even if it has only one
+      # value. Prior to 4.x (and unless using the future parser in
+      # 3.x), Puppet would munge single-parameter arrays into scalar
+      # values. See also
+      # https://tickets.puppetlabs.com/browse/PUP-1299.
+      munge do |value|
+        value = [value] unless value.is_a?(Array)
+      end
+        
       # Have to redefine should= here so we can sort the array that is given to
       # us by the manifest.  While were checking on the class of our value we
-      # are going to go ahead and do some validation too.  The way Corosync
-      # colocation works we need to only accept two value arrays.
+      # are going to go ahead and do some validation too.
       def should=(value)
         super
-        raise Puppet::Error, "Puppet::Type::Cs_Group: primitives property must be at least a 2-element array." unless value.is_a? Array and value.length > 1
+        raise Puppet::Error, "Puppet::Type::Cs_Group: primitives property must be at least a 1-element array." unless value.is_a? Array and value.length >= 1
         @should
       end
     end


### PR DESCRIPTION
cs_colocation, when used with the pcs provider, makes the incorrect
assumption that the order of primitives in colocation constraints is
arbitrary. It is not, and the following must not be equivalent:

cs_colocation { 'vip_with_service':
  primitives => [ 'nginx_vip', 'nginx_service' ],
}

cs_colocation { 'vip_with_service':
  primitives => [ 'nginx_service', 'nginx_vip' ],
}

These mean different things. The first example ensures that nginx_vip
runs on whatever node nginx_service runs on, and if nginx_service
can't be started on any node, Pacemaker won't even attempt to start
nginx_vip. However, if nginx_vip cannot be started on any node,
nginx_service will continue to be available.

The second example means the opposite. In it, nginx_service is
configured to run wherever nginx_vip runs, and if nginx_vip can't run
anywhere, nginx_service won't start. And if nginx_vip cannot be
started on any node, nginx_service will not be available.

As a result, drop artificial sorting for the primitives, and use them
exactly as specified.

Fixes issue puppet-community/puppet-corosync#150.