### PR TITLE
Fix acceptance tests for RHEL6 and Ubuntu 14.04

### DIFF
--- a/spec/acceptance/cs_colocation_spec.rb
+++ b/spec/acceptance/cs_colocation_spec.rb
@@ -30,7 +30,7 @@ NWyN0RsTXFaqowV1/HSyvfD7LoF/CrmN5gOAM3Ierv/Ti9uqGVhdGBd/kw=='
       class { 'corosync':
         multicast_address => '224.0.0.1',
         authkey           => '/tmp/ca.pem',
-        bind_address      => $ipaddress,
+        bind_address      => '127.0.0.1',
         set_votequorum    => true,
         quorum_members    => ['127.0.0.1'],
       }
@@ -38,8 +38,18 @@ NWyN0RsTXFaqowV1/HSyvfD7LoF/CrmN5gOAM3Ierv/Ti9uqGVhdGBd/kw=='
         version => '1',
         before  => Service['pacemaker'],
       }
+      if $::osfamily == 'RedHat' {
+        exec { 'stop_pacemaker':
+          command     => 'service pacemaker stop',
+          path        => ['/bin','/sbin','/usr/sbin/'],
+          refreshonly => true,
+          notify      => Service['corosync'],
+          subscribe   => File['/etc/corosync/corosync.conf'],
+        }
+      }
       service { 'pacemaker':
-        ensure => running,
+        ensure    => running,
+        subscribe => Service['corosync'],
       }
       cs_property { 'stonith-enabled' :
         value   => 'false',


### PR DESCRIPTION
Acceptance tests were failing on Ubuntu Trusty because the quorum
members must include at least one node that matches the bind address,
and were failing on CentOS 6 because the corosync package on CentOS 6
does not properly stop the pacemaker service before trying to restart
the corosync service. This patch fixes the tests by fixing the
quorum_members array and adding an exec to stop pacemaker when
refreshing corosync.

These still do not pass on RHEL 7, Debian, or Ubuntu < 14.04 :(