### PR TITLE
Use Puppet::Type.newtype instead of Puppet.newtype

### DIFF
--- a/lib/puppet/type/cs_clone.rb
+++ b/lib/puppet/type/cs_clone.rb
@@ -1,81 +1,79 @@
-module Puppet
-  newtype(:cs_clone) do
-    @doc = "Type for manipulating corosync/pacemaker resource clone.
-      More information on Corosync/Pacemaker colocation can be found here:
+Puppet::Type.newtype(:cs_clone) do
+  @doc = "Type for manipulating corosync/pacemaker resource clone.
+    More information on Corosync/Pacemaker colocation can be found here:
 
-      * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_ensuring_resources_run_on_the_same_host.html"
+    * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_ensuring_resources_run_on_the_same_host.html"
 
-    ensurable
+  ensurable
 
-    newparam(:name) do
-      desc "Identifier of the location entry.  This value needs to be unique
-        across the entire Corosync/Pacemaker configuration since it doesn't have
-        the concept of name spaces per type."
+  newparam(:name) do
+    desc "Identifier of the location entry.  This value needs to be unique
+      across the entire Corosync/Pacemaker configuration since it doesn't have
+      the concept of name spaces per type."
 
-      isnamevar
-    end
-
-    newproperty(:primitive) do
-      desc "The corosync resource primitive to be cloned.  "
-    end
-
-    newproperty(:clone_max) do
-      desc "How many copies of the resource to start.
-        Defaults to the number of nodes in the cluster."
-    end
-    newproperty(:clone_node_max) do
-      desc "How many copies of the resource can be started on a single node.
-      Defaults to 1."
-    end
-
-    newproperty(:notify_clones) do
-      desc "When stopping or starting a copy of the clone, tell all the other copies beforehand
-        and when the action was successful.
-        Allowed values: true, false"
-
-        newvalues(:true, :false)
-    end
-
-    newproperty(:globally_unique) do
-      desc "Does each copy of the clone perform a different function?
-        Allowed values: true, false"
-
-        newvalues(:true, :false)
-    end
-
-    newproperty(:ordered) do
-      desc "Should the copies be started in series (instead of in parallel). Allowed values: true, false"
-
-        newvalues(:true, :false)
-    end
-
-    newproperty(:interleave) do
-      desc "Changes the behavior of ordering constraints (between clones/masters) so that instances can start/stop
-        as soon as their peer instance has (rather than waiting for every instance of the other clone has).
-        Allowed values: true, false"
-
-        newvalues(:true, :false)
-    end
-
-    newparam(:cib) do
-      desc "Corosync applies its configuration immediately. Using a CIB allows
-        you to group multiple primitives and relationships to be applied at
-        once. This can be necessary to insert complex configurations into
-        Corosync correctly.
-
-        This paramater sets the CIB this colocation should be created in. A
-        cs_shadow resource with a title of the same name as this value should
-        also be added to your manifest."
-    end
-
-    autorequire(:cs_shadow) do
-      [ @parameters[:cib] ]
-    end
-
-    autorequire(:service) do
-      [ 'corosync' ]
-    end
-
+    isnamevar
   end
+
+  newproperty(:primitive) do
+    desc "The corosync resource primitive to be cloned.  "
+  end
+
+  newproperty(:clone_max) do
+    desc "How many copies of the resource to start.
+      Defaults to the number of nodes in the cluster."
+  end
+  newproperty(:clone_node_max) do
+    desc "How many copies of the resource can be started on a single node.
+    Defaults to 1."
+  end
+
+  newproperty(:notify_clones) do
+    desc "When stopping or starting a copy of the clone, tell all the other copies beforehand
+      and when the action was successful.
+      Allowed values: true, false"
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:globally_unique) do
+    desc "Does each copy of the clone perform a different function?
+      Allowed values: true, false"
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:ordered) do
+    desc "Should the copies be started in series (instead of in parallel). Allowed values: true, false"
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:interleave) do
+    desc "Changes the behavior of ordering constraints (between clones/masters) so that instances can start/stop
+      as soon as their peer instance has (rather than waiting for every instance of the other clone has).
+      Allowed values: true, false"
+
+    newvalues(:true, :false)
+  end
+
+  newparam(:cib) do
+    desc "Corosync applies its configuration immediately. Using a CIB allows
+      you to group multiple primitives and relationships to be applied at
+      once. This can be necessary to insert complex configurations into
+      Corosync correctly.
+
+      This paramater sets the CIB this colocation should be created in. A
+      cs_shadow resource with a title of the same name as this value should
+      also be added to your manifest."
+  end
+
+  autorequire(:cs_shadow) do
+    [ @parameters[:cib] ]
+  end
+
+  autorequire(:service) do
+    [ 'corosync' ]
+  end
+
 end
 

--- a/lib/puppet/type/cs_colocation.rb
+++ b/lib/puppet/type/cs_colocation.rb
@@ -1,102 +1,100 @@
-module Puppet
-  newtype(:cs_colocation) do
-    @doc = "Type for manipulating corosync/pacemaker colocation.  Colocation
-      is the grouping together of a set of primitives so that they travel
-      together when one of them fails.  For instance, if a web server vhost
-      is colocated with a specific ip address and the web server software
-      crashes, the ip address with migrate to the new host with the vhost.
+Puppet::Type.newtype(:cs_colocation) do
+  @doc = "Type for manipulating corosync/pacemaker colocation.  Colocation
+    is the grouping together of a set of primitives so that they travel
+    together when one of them fails.  For instance, if a web server vhost
+    is colocated with a specific ip address and the web server software
+    crashes, the ip address with migrate to the new host with the vhost.
 
-      More information on Corosync/Pacemaker colocation can be found here:
+    More information on Corosync/Pacemaker colocation can be found here:
 
-      * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_ensuring_resources_run_on_the_same_host.html"
+    * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_ensuring_resources_run_on_the_same_host.html"
 
-    ensurable
+  ensurable
 
-    newparam(:name) do
-      desc "Identifier of the colocation entry.  This value needs to be unique
+  newparam(:name) do
+    desc "Identifier of the colocation entry.  This value needs to be unique
         across the entire Corosync/Pacemaker configuration since it doesn't have
         the concept of name spaces per type."
 
-      isnamevar
-    end
+    isnamevar
+  end
 
-    newproperty(:primitives, :array_matching => :all) do
-      desc "At least two Pacemaker primitives to be located together. Order of primitives
-        in colocation groups is important. In Pacemaker, a colocation of 2 primitives
-        behaves different than a colocation between more than 2 primitives. Here the
-        behavior is altered to be more consistent.
-        Examples on how to define colocations here:
-        - 2 primitives: [A, B] will cause A to be located first, and B will be located
-          with A. This is different than how crm configure colocation works, because
-          there [A, B] would mean colocate A with B, thus B should be located first.
-        - multiple primitives: [A, B, C] will cause A to be located first, B next, and
-          finally C. This is identical to how crm configure colocation works with
-          multiple resources, it will add a colocated set.
-        Property will raise an error if you do not provide an array containing at least
-        two values. Values can be either the name of the primitive, or primitive:role.
-        Notice, we can only interpret colocations of single sets, not multiple sets
-        combined. In Pacemaker speak, this means we can support 'A B C' but not e.g.
-        'A B (C D) E'. Feel free to contribute a patch for this."
+  newproperty(:primitives, :array_matching => :all) do
+    desc "At least two Pacemaker primitives to be located together. Order of primitives
+      in colocation groups is important. In Pacemaker, a colocation of 2 primitives
+      behaves different than a colocation between more than 2 primitives. Here the
+      behavior is altered to be more consistent.
+      Examples on how to define colocations here:
+      - 2 primitives: [A, B] will cause A to be located first, and B will be located
+        with A. This is different than how crm configure colocation works, because
+        there [A, B] would mean colocate A with B, thus B should be located first.
+      - multiple primitives: [A, B, C] will cause A to be located first, B next, and
+        finally C. This is identical to how crm configure colocation works with
+        multiple resources, it will add a colocated set.
+      Property will raise an error if you do not provide an array containing at least
+      two values. Values can be either the name of the primitive, or primitive:role.
+      Notice, we can only interpret colocations of single sets, not multiple sets
+      combined. In Pacemaker speak, this means we can support 'A B C' but not e.g.
+      'A B (C D) E'. Feel free to contribute a patch for this."
 
-      # Do some validation: the way Pacemaker colocation works we need to only accept
-      # arrays with at least 2 values.
-      def should=(value)
-        super
-        if value.is_a? Array
-          raise Puppet::Error, "Puppet::Type::Cs_Colocation: The primitives property must be an array of at least two primitives." unless value.size >= 2
-          @should
-        else
-          raise Puppet::Error, "Puppet::Type::Cs_Colocation: The primitives property must be an array."
-          @should
-        end
+    # Do some validation: the way Pacemaker colocation works we need to only accept
+    # arrays with at least 2 values.
+    def should=(value)
+      super
+      if value.is_a? Array
+        raise Puppet::Error, "Puppet::Type::Cs_Colocation: The primitives property must be an array of at least two primitives." unless value.size >= 2
+        @should
+      else
+        raise Puppet::Error, "Puppet::Type::Cs_Colocation: The primitives property must be an array."
+        @should
       end
     end
+  end
 
-    newparam(:cib) do
-      desc "Corosync applies its configuration immediately. Using a CIB allows
-        you to group multiple primitives and relationships to be applied at
-        once. This can be necessary to insert complex configurations into
-        Corosync correctly.
+  newparam(:cib) do
+    desc "Corosync applies its configuration immediately. Using a CIB allows
+      you to group multiple primitives and relationships to be applied at
+      once. This can be necessary to insert complex configurations into
+      Corosync correctly.
 
-        This paramater sets the CIB this colocation should be created in. A
-        cs_shadow resource with a title of the same name as this value should
-        also be added to your manifest."
+      This paramater sets the CIB this colocation should be created in. A
+      cs_shadow resource with a title of the same name as this value should
+      also be added to your manifest."
+  end
+
+  newproperty(:score) do
+    desc "The priority of this colocation.  Primitives can be a part of
+      multiple colocation groups and so there is a way to control which
+      primitives get priority when forcing the move of other primitives.
+      This value can be an integer but is often defined as the string
+      INFINITY."
+
+    defaultto 'INFINITY'
+  end
+
+  autorequire(:cs_shadow) do
+    [ @parameters[:cib] ]
+  end
+
+  autorequire(:service) do
+    [ 'corosync' ]
+  end
+
+  autorequire(:cs_primitive) do
+    autos = []
+    @parameters[:primitives].should.each do |val|
+      autos << unmunge_cs_primitive(val)
     end
 
-    newproperty(:score) do
-      desc "The priority of this colocation.  Primitives can be a part of
-        multiple colocation groups and so there is a way to control which
-        primitives get priority when forcing the move of other primitives.
-        This value can be an integer but is often defined as the string
-        INFINITY."
+    autos
+  end
 
-        defaultto 'INFINITY'
+  def unmunge_cs_primitive(name)
+    name = name.split(':')[0]
+    if name.start_with? 'ms_'
+      name = name[3..-1]
     end
 
-    autorequire(:cs_shadow) do
-      [ @parameters[:cib] ]
-    end
-
-    autorequire(:service) do
-      [ 'corosync' ]
-    end
-
-    autorequire(:cs_primitive) do
-      autos = []
-      @parameters[:primitives].should.each do |val|
-        autos << unmunge_cs_primitive(val)
-      end
-
-      autos
-    end
-
-    def unmunge_cs_primitive(name)
-      name = name.split(':')[0]
-      if name.start_with? 'ms_'
-        name = name[3..-1]
-      end
-
-      name
-    end
+    name
   end
 end

--- a/lib/puppet/type/cs_commit.rb
+++ b/lib/puppet/type/cs_commit.rb
@@ -1,59 +1,57 @@
-module Puppet
-  newtype(:cs_commit) do
-    @doc = "This type is an implementation detail. DO NOT use it directly"
-    newproperty(:cib) do
-      def sync
-        provider.sync(self.should)
-      end
-
-      def retrieve
-        :absent
-      end
-
-      def insync?(is)
-        false
-      end
-
-      defaultto { @resource[:name] }
+Puppet::Type.newtype(:cs_commit) do
+  @doc = "This type is an implementation detail. DO NOT use it directly"
+  newproperty(:cib) do
+    def sync
+      provider.sync(self.should)
     end
 
-    newparam(:name) do
-      isnamevar
+    def retrieve
+      :absent
     end
 
-    autorequire(:cs_shadow) do
-      [ @parameters[:cib].should ]
+    def insync?(is)
+      false
     end
 
-    autorequire(:service) do
-      [ 'corosync' ]
+    defaultto { @resource[:name] }
+  end
+
+  newparam(:name) do
+    isnamevar
+  end
+
+  autorequire(:cs_shadow) do
+    [ @parameters[:cib].should ]
+  end
+
+  autorequire(:service) do
+    [ 'corosync' ]
+  end
+
+  autorequire(:cs_primitive) do
+    resources_with_cib :cs_primitive
+  end
+
+  autorequire(:cs_colocation) do
+    resources_with_cib :cs_colocation
+  end
+
+  autorequire(:cs_location) do
+    resources_with_cib :cs_location
+  end
+
+
+  autorequire(:cs_order) do
+    resources_with_cib :cs_order
+  end
+
+  def resources_with_cib(cib)
+    autos = []
+
+    catalog.resources.find_all { |r| r.is_a?(Puppet::Type.type(cib)) and param = r.parameter(:cib) and param.value == @parameters[:cib].should }.each do |r|
+      autos << r
     end
 
-    autorequire(:cs_primitive) do
-      resources_with_cib :cs_primitive
-    end
-
-    autorequire(:cs_colocation) do
-      resources_with_cib :cs_colocation
-    end
-
-    autorequire(:cs_location) do
-      resources_with_cib :cs_location
-    end
-
-
-    autorequire(:cs_order) do
-      resources_with_cib :cs_order
-    end
-
-    def resources_with_cib(cib)
-      autos = []
-
-      catalog.resources.find_all { |r| r.is_a?(Puppet::Type.type(cib)) and param = r.parameter(:cib) and param.value == @parameters[:cib].should }.each do |r|
-        autos << r
-      end
-
-      autos
-    end
+    autos
   end
 end

--- a/lib/puppet/type/cs_group.rb
+++ b/lib/puppet/type/cs_group.rb
@@ -1,72 +1,70 @@
-module Puppet
-  newtype(:cs_group) do
-    @doc = "Type for manipulating Corosync/Pacemkaer group entries.
-      Groups are a set or resources (primitives) that need to be
-      grouped together.
+Puppet::Type.newtype(:cs_group) do
+  @doc = "Type for manipulating Corosync/Pacemkaer group entries.
+    Groups are a set or resources (primitives) that need to be
+    grouped together.
 
-      More information can be found at the following link:
+    More information can be found at the following link:
 
-      * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/ch-advanced-resources.html#group-resources"
+    * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/ch-advanced-resources.html#group-resources"
 
-    ensurable
+  ensurable
 
-    newparam(:name) do
-      desc "Name identifier of this group entry.  This value needs to be unique
-        across the entire Corosync/Pacemaker configuration since it doesn't have
-        the concept of name spaces per type."
-      isnamevar
+  newparam(:name) do
+    desc "Name identifier of this group entry.  This value needs to be unique
+      across the entire Corosync/Pacemaker configuration since it doesn't have
+      the concept of name spaces per type."
+    isnamevar
+  end
+
+  newproperty(:primitives, :array_matching => :all) do
+    desc "An array of primitives to have in this group.  Must be listed in the
+      order that you wish them to start."
+
+    # Have to redefine should= here so we can sort the array that is given to
+    # us by the manifest.  While were checking on the class of our value we
+    # are going to go ahead and do some validation too.  The way Corosync
+    # colocation works we need to only accept two value arrays.
+    def should=(value)
+      super
+      raise Puppet::Error, "Puppet::Type::Cs_Group: primitives property must be at least a 2-element array." unless value.is_a? Array and value.length > 1
+      @should
+    end
+  end
+
+  newparam(:cib) do
+    desc "Corosync applies its configuration immediately. Using a CIB allows
+      you to group multiple primitives and relationships to be applied at
+      once. This can be necessary to insert complex configurations into
+      Corosync correctly.
+
+      This paramater sets the CIB this order should be created in. A
+      cs_shadow resource with a title of the same name as this value should
+      also be added to your manifest."
+  end
+
+  autorequire(:cs_shadow) do
+    [ @parameters[:cib] ]
+  end
+
+  autorequire(:service) do
+    [ 'corosync' ]
+  end
+
+  autorequire(:cs_primitive) do
+    autos = []
+    @parameters[:primitives].should.each do |val|
+      autos << unmunge_cs_primitive(val)
     end
 
-    newproperty(:primitives, :array_matching => :all) do
-      desc "An array of primitives to have in this group.  Must be listed in the
-          order that you wish them to start."
+    autos
+  end
 
-      # Have to redefine should= here so we can sort the array that is given to
-      # us by the manifest.  While were checking on the class of our value we
-      # are going to go ahead and do some validation too.  The way Corosync
-      # colocation works we need to only accept two value arrays.
-      def should=(value)
-        super
-        raise Puppet::Error, "Puppet::Type::Cs_Group: primitives property must be at least a 2-element array." unless value.is_a? Array and value.length > 1
-        @should
-      end
+  def unmunge_cs_primitive(name)
+    name = name.split(':')[0]
+    if name.start_with? 'ms_'
+      name = name[3..-1]
     end
 
-    newparam(:cib) do
-      desc "Corosync applies its configuration immediately. Using a CIB allows
-        you to group multiple primitives and relationships to be applied at
-        once. This can be necessary to insert complex configurations into
-        Corosync correctly.
-
-        This paramater sets the CIB this order should be created in. A
-        cs_shadow resource with a title of the same name as this value should
-        also be added to your manifest."
-    end
-
-    autorequire(:cs_shadow) do
-      [ @parameters[:cib] ]
-    end
-
-    autorequire(:service) do
-      [ 'corosync' ]
-    end
-
-    autorequire(:cs_primitive) do
-      autos = []
-      @parameters[:primitives].should.each do |val|
-        autos << unmunge_cs_primitive(val)
-      end
-
-      autos
-    end
-
-    def unmunge_cs_primitive(name)
-      name = name.split(':')[0]
-      if name.start_with? 'ms_'
-        name = name[3..-1]
-      end
-
-      name
-    end
+    name
   end
 end

--- a/lib/puppet/type/cs_location.rb
+++ b/lib/puppet/type/cs_location.rb
@@ -1,56 +1,54 @@
-module Puppet
-  newtype(:cs_location) do
-    @doc = "Type for manipulating corosync/pacemaker resource location.
-      More information on Corosync/Pacemaker colocation can be found here:
+Puppet::Type.newtype(:cs_location) do
+  @doc = "Type for manipulating corosync/pacemaker resource location.
+    More information on Corosync/Pacemaker colocation can be found here:
 
-      * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_ensuring_resources_run_on_the_same_host.html"
+    * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_ensuring_resources_run_on_the_same_host.html"
 
-    ensurable
+  ensurable
 
-    newparam(:name) do
-      desc "Identifier of the location entry.  This value needs to be unique
-        across the entire Corosync/Pacemaker configuration since it doesn't have
-        the concept of name spaces per type."
+  newparam(:name) do
+    desc "Identifier of the location entry.  This value needs to be unique
+      across the entire Corosync/Pacemaker configuration since it doesn't have
+      the concept of name spaces per type."
 
-      isnamevar
-    end
-
-    newproperty(:primitive) do
-      desc "The corosync resource primitive to have a location applied.  "
-    end
-
-    newproperty(:node_name) do
-      desc "The corosync node_name where the resource should be located.  "
-    end
-
-    newparam(:cib) do
-      desc "Corosync applies its configuration immediately. Using a CIB allows
-        you to group multiple primitives and relationships to be applied at
-        once. This can be necessary to insert complex configurations into
-        Corosync correctly.
-
-        This paramater sets the CIB this colocation should be created in. A
-        cs_shadow resource with a title of the same name as this value should
-        also be added to your manifest."
-    end
-
-    newproperty(:score) do
-      desc "The priority of this location.  Primitives can be a part of
-        multiple location groups and so there is a way to control which
-        primitives get priority when forcing the move of other primitives.
-        This value can be an integer but is often defined as the string
-        INFINITY."
-
-        defaultto 'INFINITY'
-    end
-
-    autorequire(:cs_shadow) do
-      [ @parameters[:cib] ]
-    end
-
-    autorequire(:service) do
-      [ 'corosync' ]
-    end
-
+    isnamevar
   end
+
+  newproperty(:primitive) do
+    desc "The corosync resource primitive to have a location applied.  "
+  end
+
+  newproperty(:node_name) do
+    desc "The corosync node_name where the resource should be located.  "
+  end
+
+  newparam(:cib) do
+    desc "Corosync applies its configuration immediately. Using a CIB allows
+      you to group multiple primitives and relationships to be applied at
+      once. This can be necessary to insert complex configurations into
+      Corosync correctly.
+
+      This paramater sets the CIB this colocation should be created in. A
+      cs_shadow resource with a title of the same name as this value should
+      also be added to your manifest."
+  end
+
+  newproperty(:score) do
+    desc "The priority of this location.  Primitives can be a part of
+      multiple location groups and so there is a way to control which
+      primitives get priority when forcing the move of other primitives.
+      This value can be an integer but is often defined as the string
+      INFINITY."
+
+    defaultto 'INFINITY'
+  end
+
+  autorequire(:cs_shadow) do
+    [ @parameters[:cib] ]
+  end
+
+  autorequire(:service) do
+    [ 'corosync' ]
+  end
+
 end

--- a/lib/puppet/type/cs_order.rb
+++ b/lib/puppet/type/cs_order.rb
@@ -1,104 +1,102 @@
-module Puppet
-  newtype(:cs_order) do
-    @doc = "Type for manipulating Corosync/Pacemkaer ordering entries.  Order
-      entries are another type of constraint that can be put on sets of
-      primitives but unlike colocation, order does matter.  These designate
-      the order at which you need specific primitives to come into a desired
-      state before starting up a related primitive.
+Puppet::Type.newtype(:cs_order) do
+  @doc = "Type for manipulating Corosync/Pacemkaer ordering entries.  Order
+    entries are another type of constraint that can be put on sets of
+    primitives but unlike colocation, order does matter.  These designate
+    the order at which you need specific primitives to come into a desired
+    state before starting up a related primitive.
 
-      More information can be found at the following link:
+    More information can be found at the following link:
 
-      * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_controlling_resource_start_stop_ordering.html"
+    * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_controlling_resource_start_stop_ordering.html"
 
-    ensurable
+  ensurable
 
-    newparam(:name) do
-      desc "Name identifier of this ordering entry.  This value needs to be unique
-        across the entire Corosync/Pacemaker configuration since it doesn't have
-        the concept of name spaces per type."
-      isnamevar
-    end
+  newparam(:name) do
+    desc "Name identifier of this ordering entry.  This value needs to be unique
+      across the entire Corosync/Pacemaker configuration since it doesn't have
+      the concept of name spaces per type."
+    isnamevar
+  end
 
-    newproperty(:first) do
-      desc "First Corosync primitive.  Just like colocation, our primitives for
-        ording come in pairs but this time order matters so we need to define
-        which primitive starts the desired state change chain."
-    end
+  newproperty(:first) do
+    desc "First Corosync primitive.  Just like colocation, our primitives for
+      ording come in pairs but this time order matters so we need to define
+      which primitive starts the desired state change chain."
+  end
 
-    newproperty(:second) do
-      desc "Second Corosync primitive.  Our second primitive will move to the
-        desired state after the first primitive."
-    end
+  newproperty(:second) do
+    desc "Second Corosync primitive.  Our second primitive will move to the
+      desired state after the first primitive."
+  end
 
-    newparam(:cib) do
-      desc "Corosync applies its configuration immediately. Using a CIB allows
-        you to group multiple primitives and relationships to be applied at
-        once. This can be necessary to insert complex configurations into
-        Corosync correctly.
+  newparam(:cib) do
+    desc "Corosync applies its configuration immediately. Using a CIB allows
+      you to group multiple primitives and relationships to be applied at
+      once. This can be necessary to insert complex configurations into
+      Corosync correctly.
 
-        This paramater sets the CIB this order should be created in. A
-        cs_shadow resource with a title of the same name as this value should
-        also be added to your manifest."
-    end
+      This paramater sets the CIB this order should be created in. A
+      cs_shadow resource with a title of the same name as this value should
+      also be added to your manifest."
+  end
 
-    newproperty(:score) do
-      desc "The priority of the this ordered grouping.  Primitives can be a part
-        of multiple order groups and so there is a way to control which
-        primitives get priority when forcing the order of state changes on
-        other primitives.  This value can be an integer but is often defined
-        as the string INFINITY."
+  newproperty(:score) do
+    desc "The priority of the this ordered grouping.  Primitives can be a part
+      of multiple order groups and so there is a way to control which
+      primitives get priority when forcing the order of state changes on
+      other primitives.  This value can be an integer but is often defined
+      as the string INFINITY."
 
-      defaultto 'INFINITY'
-    end
+    defaultto 'INFINITY'
+  end
 
-    autorequire(:cs_shadow) do
-      [ @parameters[:cib] ]
-    end
-    newproperty(:symmetrical) do
-      desc "Boolean specifying if the resources should stop in reverse order.
+  autorequire(:cs_shadow) do
+    [ @parameters[:cib] ]
+  end
+  newproperty(:symmetrical) do
+    desc "Boolean specifying if the resources should stop in reverse order.
         Default value: true."
-      defaultto true
+    defaultto true
+  end
+
+  valid_resource_types = [:cs_primitive, :cs_group]
+  newparam(:resources_type) do
+    desc "String to specify which HA resource type is used for this order,
+      e.g. when you want to order groups (cs_group) instead of primitives.
+      Defaults to cs_primitive."
+
+    defaultto :cs_primitive
+    validate do |value|
+      valid_resource_types.include? value
     end
+  end
 
-    valid_resource_types = [:cs_primitive, :cs_group]
-    newparam(:resources_type) do
-      desc "String to specify which HA resource type is used for this order,
-        e.g. when you want to order groups (cs_group) instead of primitives.
-        Defaults to cs_primitive."
+  autorequire(:service) do
+    [ 'corosync' ]
+  end
 
-      defaultto :cs_primitive
-      validate do |value|
-        valid_resource_types.include? value
-      end
-    end
-
-    autorequire(:service) do
-      [ 'corosync' ]
-    end
-
-    valid_resource_types.each{ |possible_resource_type|
-      # We're generating autorequire blocks for all possible cs_ types because
-      # accessing the @parameters[:resources_type].value doesn't seem possible
-      # when the type is declared. Feel free to improve this.
-      autorequire(possible_resource_type) do
-        autos = []
-        resource_type = @parameters[:resources_type].value
-        if resource_type.to_sym == possible_resource_type.to_sym
-          autos << unmunge_cs_resourcename(@parameters[:first].should)
-          autos << unmunge_cs_resourcename(@parameters[:second].should)
-        end
-
-        autos
-      end
-    }
-
-    def unmunge_cs_resourcename(name)
-      name = name.split(':')[0]
-      if name.start_with? 'ms_'
-        name = name[3..-1]
+  valid_resource_types.each{ |possible_resource_type|
+    # We're generating autorequire blocks for all possible cs_ types because
+    # accessing the @parameters[:resources_type].value doesn't seem possible
+    # when the type is declared. Feel free to improve this.
+    autorequire(possible_resource_type) do
+      autos = []
+      resource_type = @parameters[:resources_type].value
+      if resource_type.to_sym == possible_resource_type.to_sym
+        autos << unmunge_cs_resourcename(@parameters[:first].should)
+        autos << unmunge_cs_resourcename(@parameters[:second].should)
       end
 
-      name
+      autos
     end
+  }
+
+  def unmunge_cs_resourcename(name)
+    name = name.split(':')[0]
+    if name.start_with? 'ms_'
+      name = name[3..-1]
+    end
+
+    name
   end
 end

--- a/lib/puppet/type/cs_primitive.rb
+++ b/lib/puppet/type/cs_primitive.rb
@@ -1,173 +1,171 @@
-module Puppet
-  newtype(:cs_primitive) do
-    @doc = "Type for manipulating Corosync/Pacemaker primitives.  Primitives
-      are probably the most important building block when creating highly
-      available clusters using Corosync and Pacemaker.  Each primitive defines
-      an application, ip address, or similar to monitor and maintain.  These
-      managed primitives are maintained using what is called a resource agent.
-      These resource agents have a concept of class, type, and subsystem that
-      provides the functionality.  Regretibly these pieces of vocabulary
-      clash with those used in Puppet so to overcome the name clashing the
-      property and parameter names have been qualified a bit for clarity.
+Puppet::Type.newtype(:cs_primitive) do
+  @doc = "Type for manipulating Corosync/Pacemaker primitives.  Primitives
+    are probably the most important building block when creating highly
+    available clusters using Corosync and Pacemaker.  Each primitive defines
+    an application, ip address, or similar to monitor and maintain.  These
+    managed primitives are maintained using what is called a resource agent.
+    These resource agents have a concept of class, type, and subsystem that
+    provides the functionality.  Regretibly these pieces of vocabulary
+    clash with those used in Puppet so to overcome the name clashing the
+    property and parameter names have been qualified a bit for clarity.
 
-      More information on primitive definitions can be found at the following
-      link:
+    More information on primitive definitions can be found at the following
+    link:
 
-      * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_adding_a_resource.html"
+    * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_adding_a_resource.html"
 
-    ensurable
+  ensurable
 
-    newparam(:name) do
-      desc "Name identifier of primitive.  This value needs to be unique
-        across the entire Corosync/Pacemaker configuration since it doesn't have
-        the concept of name spaces per type."
+  newparam(:name) do
+    desc "Name identifier of primitive.  This value needs to be unique
+      across the entire Corosync/Pacemaker configuration since it doesn't have
+      the concept of name spaces per type."
 
-      isnamevar
+    isnamevar
+  end
+
+  newparam(:primitive_class) do
+    desc "Corosync class of the primitive.  Examples of classes are lsb or ocf.
+      Lsb funtions a lot like the init provider in Puppet for services, an init
+      script is ran periodically on each host to identify status, or to start
+      and stop a particular application.  Ocf of the other hand is a script with
+      meta-data and stucture that is specific to Corosync and Pacemaker."
+  end
+
+  newparam(:primitive_type) do
+    desc "Corosync primitive type.  Type generally matches to the specific
+      'thing' your managing, i.e. ip address or vhost.  Though, they can be
+      completely arbitarily named and manage any number of underlying
+      applications or resources."
+  end
+
+  newparam(:provided_by) do
+    desc "Corosync primitive provider.  All resource agents used in a primitve
+      have something that provides them to the system, be it the Pacemaker or
+      redhat plugins...they're not always obvious though so currently you're
+      left to understand Corosync enough to figure it out.  Usually, if it isn't
+      obvious it is because there is only one provider for the resource agent.
+
+      To find the list of providers for a resource agent run the following
+      from the command line has Corosync installed:
+
+      * `crm configure ra providers <ra> <class>`"
+  end
+
+  newparam(:cib) do
+    desc "Corosync applies its configuration immediately. Using a CIB allows
+      you to group multiple primitives and relationships to be applied at
+      once. This can be necessary to insert complex configurations into
+      Corosync correctly.
+
+      This paramater sets the CIB this primitive should be created in. A
+      cs_shadow resource with a title of the same name as this value should
+      also be added to your manifest."
+  end
+
+  # Our parameters and operations properties must be hashes.
+  newproperty(:parameters) do
+    desc "A hash of params for the primitive.  Parameters in a primitive are
+      used by the underlying resource agent, each class using them slightly
+      differently.  In ocf scripts they are exported and pulled into the
+      script as variables to be used.  Since the list of these parameters
+      are completely arbitrary and validity not enforced we simply defer
+      defining a model and just accept a hash."
+
+    validate do |value|
+      raise Puppet::Error, "Puppet::Type::Cs_Primitive: parameters property must be a hash." unless value.is_a? Hash
     end
 
-    newparam(:primitive_class) do
-      desc "Corosync class of the primitive.  Examples of classes are lsb or ocf.
-        Lsb funtions a lot like the init provider in Puppet for services, an init
-        script is ran periodically on each host to identify status, or to start
-        and stop a particular application.  Ocf of the other hand is a script with
-        meta-data and stucture that is specific to Corosync and Pacemaker."
+    defaultto Hash.new
+  end
+
+  newproperty(:operations) do
+    desc "A hash of operations for the primitive.  Operations defined in a
+      primitive are little more predictable as they are commonly things like
+      monitor or start and their values are in seconds.  Since each resource
+      agent can define its own set of operations we are going to defer again
+      and just accept a hash.  There maybe room to model this one but it
+      would require a review of all resource agents to see if each operation
+      is valid."
+
+    validate do |value|
+      raise Puppet::Error, "Puppet::Type::Cs_Primitive: operations property must be a hash." unless value.is_a? Hash
     end
 
-    newparam(:primitive_type) do
-      desc "Corosync primitive type.  Type generally matches to the specific
-        'thing' your managing, i.e. ip address or vhost.  Though, they can be
-        completely arbitarily named and manage any number of underlying
-        applications or resources."
+    defaultto Hash.new
+  end
+
+  newproperty(:utilization) do
+    desc "A hash of utilization attributes for the primitive. If nodes are
+      also configured with available resources, and Pacemaker's placement
+      stratgey is set appropriately, then Pacemaker can place primitives on
+      nodes only where resources are available.
+
+      See the Pacemaker documentation:
+
+      http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/ch11.html"
+
+    validate do |value|
+      raise Puppet::Error, "Puppet::Type::Cs_Primitive: utilization property must be a hash." unless value.is_a? Hash
     end
 
-    newparam(:provided_by) do
-      desc "Corosync primitive provider.  All resource agents used in a primitve
-        have something that provides them to the system, be it the Pacemaker or
-        redhat plugins...they're not always obvious though so currently you're
-        left to understand Corosync enough to figure it out.  Usually, if it isn't
-        obvious it is because there is only one provider for the resource agent.
+    defaultto Hash.new
+  end
 
-        To find the list of providers for a resource agent run the following
-        from the command line has Corosync installed:
+  newproperty(:metadata) do
+    desc "A hash of metadata for the primitive.  A primitive can have a set of
+      metadata that doesn't affect the underlying Corosync type/provider but
+      affect that concept of a resource.  This metadata is similar to Puppet's
+      resources resource and some meta-parameters, they change resource
+      behavior but have no affect of the data that is synced or manipulated."
 
-        * `crm configure ra providers <ra> <class>`"
+    validate do |value|
+      raise Puppet::Error, "Puppet::Type::Cs_Primitive: metadata property must be a hash." unless value.is_a? Hash
     end
 
-    newparam(:cib) do
-      desc "Corosync applies its configuration immediately. Using a CIB allows
-        you to group multiple primitives and relationships to be applied at
-        once. This can be necessary to insert complex configurations into
-        Corosync correctly.
+    defaultto Hash.new
+  end
 
-        This paramater sets the CIB this primitive should be created in. A
-        cs_shadow resource with a title of the same name as this value should
-        also be added to your manifest."
-    end
+  newproperty(:ms_metadata) do
+    desc "A hash of metadata for the master/slave primitive state."
 
-    # Our parameters and operations properties must be hashes.
-    newproperty(:parameters) do
-      desc "A hash of params for the primitive.  Parameters in a primitive are
-        used by the underlying resource agent, each class using them slightly
-        differently.  In ocf scripts they are exported and pulled into the
-        script as variables to be used.  Since the list of these parameters
-        are completely arbitrary and validity not enforced we simply defer
-        defining a model and just accept a hash."
-
-      validate do |value|
-        raise Puppet::Error, "Puppet::Type::Cs_Primitive: parameters property must be a hash." unless value.is_a? Hash
+    munge do |value_hash|
+      value_hash.inject({}) do |memo,(key,value)|
+        memo[key] = String(value)
+        memo
       end
-
-      defaultto Hash.new
     end
 
-    newproperty(:operations) do
-      desc "A hash of operations for the primitive.  Operations defined in a
-        primitive are little more predictable as they are commonly things like
-        monitor or start and their values are in seconds.  Since each resource
-        agent can define its own set of operations we are going to defer again
-        and just accept a hash.  There maybe room to model this one but it
-        would require a review of all resource agents to see if each operation
-        is valid."
-
-      validate do |value|
-        raise Puppet::Error, "Puppet::Type::Cs_Primitive: operations property must be a hash." unless value.is_a? Hash
-      end
-
-      defaultto Hash.new
+    validate do |value|
+      raise Puppet::Error, "Puppet::Type::Cs_Primitive: ms_metadata property must be a hash" unless value.is_a? Hash
     end
 
-    newproperty(:utilization) do
-      desc "A hash of utilization attributes for the primitive. If nodes are
-        also configured with available resources, and Pacemaker's placement
-        stratgey is set appropriately, then Pacemaker can place primitives on
-        nodes only where resources are available.
+    defaultto Hash.new
+  end
 
-        See the Pacemaker documentation:
+  newproperty(:promotable) do
+    desc "Designates if the primitive is capable of being managed in a master/slave
+      state.  This will create a new ms resource in your Corosync config and add
+      this primitive to it.  Concequently Corosync will be helpful and update all
+      your colocation and order resources too but Puppet won't.  Currenlty we unmunge
+      configuraiton entries that start with ms_ so that you don't have to account for
+      name change in all our manifests."
 
-        http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/ch11.html"
+    newvalues(:true, :false)
 
-      validate do |value|
-        raise Puppet::Error, "Puppet::Type::Cs_Primitive: utilization property must be a hash." unless value.is_a? Hash
-      end
+    defaultto :false
+  end
 
-      defaultto Hash.new
+  autorequire(:cs_shadow) do
+    autos = []
+    if @parameters[:cib]
+      autos << @parameters[:cib].value
     end
 
-    newproperty(:metadata) do
-      desc "A hash of metadata for the primitive.  A primitive can have a set of
-        metadata that doesn't affect the underlying Corosync type/provider but
-        affect that concept of a resource.  This metadata is similar to Puppet's
-        resources resource and some meta-parameters, they change resource
-        behavior but have no affect of the data that is synced or manipulated."
+    autos
+  end
 
-      validate do |value|
-        raise Puppet::Error, "Puppet::Type::Cs_Primitive: metadata property must be a hash." unless value.is_a? Hash
-      end
-
-      defaultto Hash.new
-    end
-
-    newproperty(:ms_metadata) do
-      desc "A hash of metadata for the master/slave primitive state."
-
-      munge do |value_hash|
-        value_hash.inject({}) do |memo,(key,value)|
-          memo[key] = String(value)
-          memo
-        end
-      end
-
-      validate do |value|
-        raise Puppet::Error, "Puppet::Type::Cs_Primitive: ms_metadata property must be a hash" unless value.is_a? Hash
-      end
-
-      defaultto Hash.new
-    end
-
-    newproperty(:promotable) do
-      desc "Designates if the primitive is capable of being managed in a master/slave
-        state.  This will create a new ms resource in your Corosync config and add
-        this primitive to it.  Concequently Corosync will be helpful and update all
-        your colocation and order resources too but Puppet won't.  Currenlty we unmunge
-        configuraiton entries that start with ms_ so that you don't have to account for
-        name change in all our manifests."
-
-        newvalues(:true, :false)
-
-        defaultto :false
-    end
-
-    autorequire(:cs_shadow) do
-      autos = []
-      if @parameters[:cib]
-        autos << @parameters[:cib].value
-      end
-
-      autos
-    end
-
-    autorequire(:service) do
-      [ 'corosync' ]
-    end
+  autorequire(:service) do
+    [ 'corosync' ]
   end
 end

--- a/lib/puppet/type/cs_property.rb
+++ b/lib/puppet/type/cs_property.rb
@@ -1,39 +1,37 @@
-module Puppet
-  newtype(:cs_property) do
-    @doc = "Type for manipulating corosync/pacemaker configuration properties.
-      Besides the configuration file that is managed by the module the contains
-      all these related Corosync types and providers, there is a set of cluster
-      properties that can be set and saved inside the CIB (A CIB being a set of
-      configuration that is synced across the cluster, it can be exported as XML
-      for processing and backup).  The type is pretty simple interface for
-      setting key/value pairs or removing them completely.  Removing them will
-      result in them taking on their default value.
+Puppet::Type.newtype(:cs_property) do
+  @doc = "Type for manipulating corosync/pacemaker configuration properties.
+    Besides the configuration file that is managed by the module the contains
+    all these related Corosync types and providers, there is a set of cluster
+    properties that can be set and saved inside the CIB (A CIB being a set of
+    configuration that is synced across the cluster, it can be exported as XML
+    for processing and backup).  The type is pretty simple interface for
+    setting key/value pairs or removing them completely.  Removing them will
+    result in them taking on their default value.
 
-      More information on cluster properties can be found here:
+    More information on cluster properties can be found here:
 
-      * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/_cluster_options.html
+    * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/_cluster_options.html
 
-      P.S Looked at generating a type dynamically from the cluster's property
-      meta-data that would result in a single type with puppet type properties
-      of every cluster property...may still do so in a later iteration."
+    P.S Looked at generating a type dynamically from the cluster's property
+    meta-data that would result in a single type with puppet type properties
+    of every cluster property...may still do so in a later iteration."
 
-    ensurable
+  ensurable
 
-    newparam(:name) do
-      desc "Name identifier of this property.  Simply the name of the cluster
-        property.  Happily most of these are unique."
+  newparam(:name) do
+    desc "Name identifier of this property.  Simply the name of the cluster
+      property.  Happily most of these are unique."
 
-      isnamevar
-    end
+    isnamevar
+  end
 
-    newproperty(:value) do
-      desc "Value of the property.  It is expected that this will be a single
-        value but we aren't validating string vs. integer vs. boolean because
-        cluster properties can range the gambit."
-    end
+  newproperty(:value) do
+    desc "Value of the property.  It is expected that this will be a single
+      value but we aren't validating string vs. integer vs. boolean because
+      cluster properties can range the gambit."
+  end
 
-    autorequire(:service) do
-      [ 'corosync' ]
-    end
+  autorequire(:service) do
+    [ 'corosync' ]
   end
 end

--- a/lib/puppet/type/cs_rsc_defaults.rb
+++ b/lib/puppet/type/cs_rsc_defaults.rb
@@ -1,32 +1,30 @@
-module Puppet
-  newtype(:cs_rsc_defaults) do
-    @doc = "Type for manipulating corosync/pacemaker global defaults for
-      resource options. The type is pretty simple interface for setting
-      key/value pairs or removing them completely.  Removing them will result
-      in them taking on their default value.
+Puppet::Type.newtype(:cs_rsc_defaults) do
+  @doc = "Type for manipulating corosync/pacemaker global defaults for
+    resource options. The type is pretty simple interface for setting
+    key/value pairs or removing them completely.  Removing them will result
+    in them taking on their default value.
 
-      More information on resource defaults can be found here:
+    More information on resource defaults can be found here:
 
-      * http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-resource-defaults.html
-      * http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-resource-options.html"
+    * http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-resource-defaults.html
+    * http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-resource-options.html"
 
-    ensurable
+  ensurable
 
-    newparam(:name) do
-      desc "Name identifier of this property.  Simply the name of the resource
-        option.  Happily most of these are unique."
+  newparam(:name) do
+    desc "Name identifier of this property.  Simply the name of the resource
+      option.  Happily most of these are unique."
 
-      isnamevar
-    end
+    isnamevar
+  end
 
-    newproperty(:value) do
-      desc "Value of the property.  It is expected that this will be a single
-        value but we aren't validating string vs. integer vs. boolean because
-        resource options can range the gambit."
-    end
+  newproperty(:value) do
+    desc "Value of the property.  It is expected that this will be a single
+      value but we aren't validating string vs. integer vs. boolean because
+      resource options can range the gambit."
+  end
 
-    autorequire(:service) do
-      [ 'corosync' ]
-    end
+  autorequire(:service) do
+    [ 'corosync' ]
   end
 end

--- a/lib/puppet/type/cs_shadow.rb
+++ b/lib/puppet/type/cs_shadow.rb
@@ -1,38 +1,36 @@
-module Puppet
-  newtype(:cs_shadow) do
-    @doc = "cs_shadow resources represent a Corosync shadow CIB. Any corosync
-      resources defined with 'cib' set to the title of a cs_shadow resource
-      will not become active until all other resources with the same cib
-      value have also been applied."
+Puppet::Type.newtype(:cs_shadow) do
+  @doc = "cs_shadow resources represent a Corosync shadow CIB. Any corosync
+    resources defined with 'cib' set to the title of a cs_shadow resource
+    will not become active until all other resources with the same cib
+    value have also been applied."
 
-    newproperty(:cib) do
-      def sync
-        provider.sync(self.should)
-      end
-
-      def retrieve
-        :absent
-      end
-
-      def insync?(is)
-        false
-      end
-
-      defaultto { @resource[:name] }
+  newproperty(:cib) do
+    def sync
+      provider.sync(self.should)
     end
 
-    newparam(:name) do
-      desc "Name of the shadow CIB to create and manage"
-      isnamevar
+    def retrieve
+      :absent
     end
 
-    def generate
-      options = { :name => @title }
-      [ Puppet::Type.type(:cs_commit).new(options) ]
+    def insync?(is)
+      false
     end
 
-    autorequire(:service) do
-      [ 'corosync' ]
-    end
+    defaultto { @resource[:name] }
+  end
+
+  newparam(:name) do
+    desc "Name of the shadow CIB to create and manage"
+    isnamevar
+  end
+
+  def generate
+    options = { :name => @title }
+    [ Puppet::Type.type(:cs_commit).new(options) ]
+  end
+
+  autorequire(:service) do
+    [ 'corosync' ]
   end
 end


### PR DESCRIPTION
In Puppet 4 we see the following warning:

    Warning: Creating cs_property via Puppet.newtype is deprecated and will
    be removed in a future release. Use Puppet::Type.newtype instead.
       (at /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:145:in
    `newtype')

This commit removes it.

It is compatible with older versions of Puppet.