### PR TITLE
metadata.json: Use SPDX standardized short identifier for license

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "0.8.0",
   "author": "puppet-community",
   "summary": "This module is a set of manifests and types/providers for quickly setting up highly available clusters using Corosync",
-  "license": "Apache License, Version 2.0",
+  "license": "Apache-2.0",
   "source": "https://github.com/puppet-community/puppet-corosync",
   "project_page": "https://github.com/puppet-community/puppet-corosync",
   "issues_url": "https://github.com/puppet-community/puppet-corosync/issues",


### PR DESCRIPTION
This commit changes the metadata.json to use the
SPDX licence short identifier in the metadata.json.

SPDX is an effort from the Linux foundation to easily
parse and identify open-source licenses. Some tools
in the Puppet Ecosystem relies on those short
identifiers, like the metadata-json-lint project.

- https://spdx.org/licenses
- https://github.com/puppet-community/metadata-json-lint