### PR TITLE
only parse cluster_property_set with id cib-bootstrap-options

### DIFF
--- a/lib/puppet/provider/cs_property/crm.rb
+++ b/lib/puppet/provider/cs_property/crm.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:cs_property).provide(:crm, :parent => Puppet::Provider::Crmsh
     end
     doc = REXML::Document.new(raw)
 
-    doc.root.elements['configuration/crm_config/cluster_property_set'].each_element do |e|
+    doc.root.elements["configuration/crm_config/cluster_property_set[@id='cib-bootstrap-options']"].each_element do |e|
       items = e.attributes
       property = { :name => items['name'], :value => items['value'] }
 

--- a/spec/unit/puppet/provider/cs_property_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_property_crm_spec.rb
@@ -12,9 +12,12 @@ describe Puppet::Type.type(:cs_property).provider(:crm) do
         <cib>
           <configuration>
             <crm_config>
-              <cluster_property_set>
+              <cluster_property_set id="cib-bootstrap-options">
                 <nvpair name="apples" value="red"/>
                 <nvpair name="oranges" value="orange"/>
+              </cluster_property_set>
+              <cluster_property_set id="redis_replication">
+                <nvpair id="redis_replication-p_redis_REPL_INFO" name="p_redis_REPL_INFO" value="node-1"/>
               </cluster_property_set>
             </crm_config>
           </configuration>


### PR DESCRIPTION
prevent wrong parsing of cluster_property_set in the crm provider,
if multiple sets are configured.